### PR TITLE
Update mimemagic to 0.3.10 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     levenshtein-ffi (1.1.0)
       ffi (~> 1.9)
     libv8 (8.4.255.0-x86_64-darwin-19)
+    libv8 (8.4.255.0-x86_64-darwin-20)
     libv8 (8.4.255.0-x86_64-linux)
     loofah (2.9.0)
       crass (~> 1.0.2)
@@ -90,7 +91,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_racer (0.3.1)
       libv8 (~> 8.4.255)
@@ -201,6 +204,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -228,4 +232,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   2.2.2
+   2.2.15


### PR DESCRIPTION
The previous version of `mimemagic` gem was removed.